### PR TITLE
refactor: image prefetch & page prefetch

### DIFF
--- a/apps/web/src/app/vague-frequency-labs/sections/hero/hero.tsx
+++ b/apps/web/src/app/vague-frequency-labs/sections/hero/hero.tsx
@@ -5,7 +5,7 @@ import { useScroll } from "motion/react";
 
 import HeroImage from "./HeroImage";
 
-const images = [
+export const VAGUE_FREQUENCY_LABS_HERO_IMAGES = [
   "/images/hero/1.png",
   "/images/hero/2.jpg",
   "/images/hero/3.jpg",
@@ -26,7 +26,7 @@ function Hero() {
       <div className="sticky top-0 flex h-screen items-center justify-center overflow-x-hidden">
         <h1 className="absolute top-[10vh] text-4xl font-bold">We are</h1>
         <div className="relative h-[400px] w-full">
-          {images.map((src, i) => (
+          {VAGUE_FREQUENCY_LABS_HERO_IMAGES.map((src, i) => (
             <HeroImage
               key={i}
               scrollYProgress={scrollYProgress}

--- a/apps/web/src/components/common/HighlightText.tsx
+++ b/apps/web/src/components/common/HighlightText.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { motion } from "motion/react";
 
@@ -9,6 +9,7 @@ interface HighlightTextProps {
   imageUrl?: string;
   isMobile?: boolean;
   routePath?: string;
+  prefetchImageList?: string[];
 }
 
 function HighlightText({
@@ -18,9 +19,22 @@ function HighlightText({
   imageUrl,
   isMobile,
   routePath,
+  prefetchImageList,
 }: HighlightTextProps) {
   const router = useRouter();
   const [isClicked, setIsClicked] = useState(false);
+  const prefetchedImages = useRef(new Set<string>());
+
+  const preloadNextPageHero = (src: string) => {
+    // 이미 prefetch된 이미지는 건너뛰기
+    if (prefetchedImages.current.has(src)) {
+      return;
+    }
+
+    const img = new Image();
+    img.src = src;
+    prefetchedImages.current.add(src);
+  };
 
   useEffect(() => {
     if (isClicked && routePath) {
@@ -34,7 +48,8 @@ function HighlightText({
 
   const handleMouseEnter = () => {
     if (routePath) {
-      router.prefetch(routePath);
+      // 한 번만 prefetch 실행
+      prefetchImageList?.forEach(preloadNextPageHero);
     }
 
     onHover(children);

--- a/apps/web/src/components/common/main/modern/main.tsx
+++ b/apps/web/src/components/common/main/modern/main.tsx
@@ -17,7 +17,7 @@ function Main() {
     router.prefetch("/vague-frequency-labs");
     router.prefetch("/celebrate-agency");
     router.prefetch("/payday-records");
-  }, []);
+  }, [router]);
 
   return (
     <section

--- a/apps/web/src/components/common/main/modern/main.tsx
+++ b/apps/web/src/components/common/main/modern/main.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { VAGUE_FREQUENCY_LABS_HERO_IMAGES } from "@/app/vague-frequency-labs/sections/hero/hero";
 import HighlightText from "@/components/common/HighlightText";
 import { COMPANY_NAME, COMPANY_SHORT_NAME } from "@/consts/company";
 import { useMobile } from "@/hooks/use-mobile";
@@ -9,6 +11,13 @@ import { motion } from "motion/react";
 function Main() {
   const isMobile = useMobile();
   const [hoveredText, setHoveredText] = useState("");
+  const router = useRouter();
+
+  useEffect(() => {
+    router.prefetch("/vague-frequency-labs");
+    router.prefetch("/celebrate-agency");
+    router.prefetch("/payday-records");
+  }, []);
 
   return (
     <section
@@ -47,6 +56,7 @@ function Main() {
         routePath={`/vague-frequency-labs`}
         isHover={hoveredText === COMPANY_NAME.VAGUE_FREQUENCY_LABS}
         imageUrl={`/images/logo/400_300/${COMPANY_SHORT_NAME.VAGUE_FREQUENCY_LABS}.png`}
+        prefetchImageList={VAGUE_FREQUENCY_LABS_HERO_IMAGES}
       >
         {COMPANY_NAME.VAGUE_FREQUENCY_LABS}
       </HighlightText>


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactored image and page prefetching mechanisms

- Exported hero images as constant for reusability

- Added image preloading on hover interactions

- Implemented route prefetching on component mount


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hero Images"] --> B["Export as Constant"]
  C["HighlightText Component"] --> D["Add Image Prefetch"]
  E["Main Component"] --> F["Add Route Prefetch"]
  B --> G["Reusable Image List"]
  D --> H["Hover-based Preloading"]
  F --> I["Mount-based Prefetching"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hero.tsx</strong><dd><code>Export hero images as reusable constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/app/vague-frequency-labs/sections/hero/hero.tsx

<ul><li>Renamed <code>images</code> array to <code>VAGUE_FREQUENCY_LABS_HERO_IMAGES</code><br> <li> Exported the constant for external usage<br> <li> Updated component to use the new constant name</ul>


</details>


  </td>
  <td><a href="https://github.com/Yeom-JinHo/v.f.labs-website/pull/22/files#diff-c98c14d9e27a206487a1bbeaeffa6f1d1978786dfaa542a2f135096797d90433">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HighlightText.tsx</strong><dd><code>Add image prefetching on hover interactions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/components/common/HighlightText.tsx

<ul><li>Added <code>prefetchImageList</code> prop for image preloading<br> <li> Implemented <code>preloadNextPageHero</code> function with duplicate prevention<br> <li> Added <code>useRef</code> to track prefetched images<br> <li> Modified hover handler to trigger image prefetching</ul>


</details>


  </td>
  <td><a href="https://github.com/Yeom-JinHo/v.f.labs-website/pull/22/files#diff-b4446ffb5ad45a221858d7ab01ecc62cf694137b6bd1fe34a11480f2bb992431">+17/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.tsx</strong><dd><code>Implement route and image prefetching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/components/common/main/modern/main.tsx

<ul><li>Added route prefetching for three company pages on mount<br> <li> Imported <code>VAGUE_FREQUENCY_LABS_HERO_IMAGES</code> constant<br> <li> Passed hero images list to <code>HighlightText</code> component<br> <li> Added <code>useRouter</code> and <code>useEffect</code> imports</ul>


</details>


  </td>
  <td><a href="https://github.com/Yeom-JinHo/v.f.labs-website/pull/22/files#diff-7dac4be89ca4983767605ed3133c2d55dbb823c0fc895d4e3731fe4e81943402">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

