### PR TITLE
fix: compact  header

### DIFF
--- a/apps/web/src/app/vague-frequency-labs/sections/header/header.tsx
+++ b/apps/web/src/app/vague-frequency-labs/sections/header/header.tsx
@@ -134,6 +134,10 @@ export default function Header() {
         initial="closed"
         animate={isOpen ? "open" : "closed"}
         className="bg-transparent md:hidden"
+        style={{
+          pointerEvents: isOpen ? "auto" : "none",
+          display: isOpen ? "block" : "none",
+        }}
       >
         <div className="flex flex-col gap-4 p-4">
           {links.map(({ title, href }, index) => (

--- a/apps/web/src/app/vague-frequency-labs/sections/header/header.tsx
+++ b/apps/web/src/app/vague-frequency-labs/sections/header/header.tsx
@@ -136,7 +136,6 @@ export default function Header() {
         className="bg-transparent md:hidden"
         style={{
           pointerEvents: isOpen ? "auto" : "none",
-          display: isOpen ? "block" : "none",
         }}
       >
         <div className="flex flex-col gap-4 p-4">

--- a/apps/web/src/app/vague-frequency-labs/sections/header/header.tsx
+++ b/apps/web/src/app/vague-frequency-labs/sections/header/header.tsx
@@ -136,6 +136,7 @@ export default function Header() {
         className="bg-transparent md:hidden"
         style={{
           pointerEvents: isOpen ? "auto" : "none",
+          visibility: isOpen ? "visible" : "hidden",
         }}
       >
         <div className="flex flex-col gap-4 p-4">

--- a/apps/web/src/components/sections/header/compact/header.tsx
+++ b/apps/web/src/components/sections/header/compact/header.tsx
@@ -134,6 +134,10 @@ export default function Header() {
         initial="closed"
         animate={isOpen ? "open" : "closed"}
         className="bg-transparent md:hidden"
+        style={{
+          pointerEvents: isOpen ? "auto" : "none",
+          display: isOpen ? "block" : "none",
+        }}
       >
         <div className="flex flex-col gap-4 p-4">
           {links.map(({ title, href }, index) => (

--- a/apps/web/src/components/sections/header/compact/header.tsx
+++ b/apps/web/src/components/sections/header/compact/header.tsx
@@ -136,7 +136,6 @@ export default function Header() {
         className="bg-transparent md:hidden"
         style={{
           pointerEvents: isOpen ? "auto" : "none",
-          display: isOpen ? "block" : "none",
         }}
       >
         <div className="flex flex-col gap-4 p-4">

--- a/apps/web/src/components/sections/header/compact/header.tsx
+++ b/apps/web/src/components/sections/header/compact/header.tsx
@@ -136,6 +136,7 @@ export default function Header() {
         className="bg-transparent md:hidden"
         style={{
           pointerEvents: isOpen ? "auto" : "none",
+          visibility: isOpen ? "visible" : "hidden",
         }}
       >
         <div className="flex flex-col gap-4 p-4">


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed mobile menu opening unexpectedly on external clicks

- Added pointer events and display controls for menu visibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Mobile Menu"] --> B["Add pointerEvents control"]
  A --> C["Add display control"]
  B --> D["Prevent external clicks"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>header.tsx</strong><dd><code>Fix mobile menu interaction controls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/app/vague-frequency-labs/sections/header/header.tsx

<ul><li>Added <code>pointerEvents</code> style property to control menu interaction<br> <li> Added <code>display</code> style property to control menu visibility<br> <li> Both properties are conditionally set based on <code>isOpen</code> state</ul>


</details>


  </td>
  <td><a href="https://github.com/Yeom-JinHo/v.f.labs-website/pull/25/files#diff-6d0b2434e3bc7580e32d4d427670f50008aa0d2f2044533bd2103c62f3a88d9d">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>header.tsx</strong><dd><code>Fix compact header menu interaction controls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/components/sections/header/compact/header.tsx

<ul><li>Added <code>pointerEvents</code> style property to control menu interaction<br> <li> Added <code>display</code> style property to control menu visibility<br> <li> Both properties are conditionally set based on <code>isOpen</code> state</ul>


</details>


  </td>
  <td><a href="https://github.com/Yeom-JinHo/v.f.labs-website/pull/25/files#diff-27d448c274c0f75877ea09e4c026c9ca49da9cbd4eaa4b9d1110a15eeb9cbbd9">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

